### PR TITLE
remove rubydox.net

### DIFF
--- a/fr/documentation/index.md
+++ b/fr/documentation/index.md
@@ -127,15 +127,12 @@ pour les nombreuses façons d'obtenir Ruby.
 : Documentation sur les API Ruby et Ruby On Rails, proposant un système
   de recherche poussé.
 
-[RubyDox][22]
-: Documentation pour Ruby, Rails, gems et plugin Rails.
-
 ### Lectures additionnelles
 
-[Ruby-Doc.org][23] maintient à jour une liste presque exhaustive de la
+[Ruby-Doc.org][22] maintient à jour une liste presque exhaustive de la
 documentation disponible en anglais. Il existe également de nombreux
-ouvrages à propos de Ruby : [une liste de livres en anglais][24]
-(relativement exhaustive) et [une liste de livres en français][25]
+ouvrages à propos de Ruby : [une liste de livres en anglais][23]
+(relativement exhaustive) et [une liste de livres en français][24]
 (incomplète). Par ailleurs, si vous avez des questions à poser sur Ruby,
 la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 à explorer.
@@ -162,7 +159,6 @@ la [liste de diffusion](/en/community/mailing-lists/) est un bon endroit
 [extensions]: https://docs.ruby-lang.org/en/trunk/extension_rdoc.html
 [20]: http://rubydoc.info/
 [21]: http://rubydocs.org/
-[22]: http://www.rubydox.net/
-[23]: http://ruby-doc.org
-[24]: http://www.ruby-doc.org/bookstore
-[25]: http://rubyfrance.org/liens/livres/
+[22]: http://ruby-doc.org
+[23]: http://www.ruby-doc.org/bookstore
+[24]: http://rubyfrance.org/liens/livres/


### PR DESCRIPTION
rubydox.net is dead and no longer about ruby.
It appears it is now a website promoting online gambling and should be removed.